### PR TITLE
Fix memory leaks related to audio buffers and Theorafile

### DIFF
--- a/MonoGame.Framework/Media/Video.cs
+++ b/MonoGame.Framework/Media/Video.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Xna.Framework.Media
         {
             if (!_disposed)
             {
-                //PlatformDispose(disposing);
+                PlatformDispose(disposing);
                 _disposed = true;
             }
         }

--- a/MonoGame.Framework/Platform/Media/Video.DesktopGL.cs
+++ b/MonoGame.Framework/Platform/Media/Video.DesktopGL.cs
@@ -99,6 +99,8 @@ namespace Microsoft.Xna.Framework.Media
 			if (theora != IntPtr.Zero)
 			{
 				Theorafile.CloseFile(ref theora);
+                Marshal.FreeHGlobal(theora);
+                theora = IntPtr.Zero;
 			}
 		}
 


### PR DESCRIPTION
As mentioned in https://github.com/MonoGame/MonoGame/pull/7448

- In VideoPlayer, audioDataPtr is not being freed when VideoPlayer is disposed, or when the video is stopped, and memory usage builds up over time;
- In Video, the instance of Theorafile which is allocated when calling OpenFile is not freed when Video is disposed, also introducing a potential memory leak. Video.Dispose is also not calling PlatformDispose.

This PR fixes both situations.